### PR TITLE
V1.6.2 channelfull fix

### DIFF
--- a/edge/pkg/edgehub/common/cacheutil/cache.go
+++ b/edge/pkg/edgehub/common/cacheutil/cache.go
@@ -8,44 +8,54 @@ import (
 	"k8s.io/klog/v2"
 )
 
+type edgeHub interface {
+	SendCacheToCloud(message model.Message) error
+}
+
 type EdgeCache struct {
 	cacheStore map[string]*model.Message
 	cacheIndex []string
 	enabled    bool
+	edgeHub    edgeHub
 	mu         sync.Mutex
 }
 
-func NewMetaCache() *EdgeCache {
+func NewMetaCache(eh edgeHub) *EdgeCache {
 	return &EdgeCache{
 		cacheStore: map[string]*model.Message{},
 		cacheIndex: []string{},
 		enabled:    false,
+		edgeHub:    eh,
 	}
 }
 
 func (ec *EdgeCache) SaveToCache(m *model.Message) error {
 	ec.mu.Lock()
-	defer ec.mu.Unlock()
 	hash := fmt.Sprintf("%s-%s-%s", m.GetResource(), m.GetOperation(), m.GetSource())
 	ec.cacheStore[hash] = m
 	ec.sortIndex(hash)
+	ec.mu.Unlock()
+	return nil
+}
+func (ec *EdgeCache) CacheToCloud() error {
+	ec.mu.Lock()
+	defer ec.mu.Unlock()
+	klog.Infof("start sending cache to cloud")
+	for len(ec.cacheIndex) > 0 {
+		name := ec.cacheIndex[0]
+		err := ec.edgeHub.SendCacheToCloud(*ec.cacheStore[name])
+		if err != nil {
+			return err
+		}
+		klog.Infof("successfully send cache %s to cloud", name)
+		ec.cacheIndex = ec.cacheIndex[1:]
+		delete(ec.cacheStore, name)
+	}
+	klog.Infof("finished sending cache to cloud")
 	return nil
 }
 func (ec *EdgeCache) GetCache() map[string]*model.Message {
 	return ec.cacheStore
-}
-func (ec *EdgeCache) GetLock() {
-	ec.mu.Lock()
-}
-func (ec *EdgeCache) ReleaseLock() {
-	ec.mu.Unlock()
-}
-func (ec *EdgeCache) RemoveCache(key string) {
-	delete(ec.cacheStore, key)
-}
-
-func (ec *EdgeCache) GetCacheIndex() []string {
-	return ec.cacheIndex
 }
 func (ec *EdgeCache) SetEnabled(enable bool) {
 	ec.enabled = enable
@@ -53,16 +63,6 @@ func (ec *EdgeCache) SetEnabled(enable bool) {
 func (ec *EdgeCache) IsEnabled() bool {
 	return ec.enabled
 }
-func (ec *EdgeCache) ShiftIndex() {
-	ec.cacheIndex = ec.cacheIndex[1:]
-}
-func (ec *EdgeCache) GetIndexLength() int {
-	return len(ec.cacheIndex)
-}
-func (ec *EdgeCache) GetFirstIndex() string {
-	return ec.cacheIndex[0]
-}
-
 func (ec *EdgeCache) sortIndex(hash string) {
 	klog.V(4).Infof("ec cacheIndex: %v", ec.cacheIndex)
 	for index, item := range ec.cacheIndex {

--- a/edge/pkg/edgehub/common/cacheutil/cache.go
+++ b/edge/pkg/edgehub/common/cacheutil/cache.go
@@ -64,7 +64,7 @@ func (ec *EdgeCache) GetFirstIndex() string {
 }
 
 func (ec *EdgeCache) sortIndex(hash string) {
-	klog.Infof("ec cacheIndex: %v", ec.cacheIndex)
+	klog.V(4).Infof("ec cacheIndex: %v", ec.cacheIndex)
 	for index, item := range ec.cacheIndex {
 		if item == hash {
 			if (index + 1) != len(ec.cacheIndex) {

--- a/edge/pkg/edgehub/common/cacheutil/cache.go
+++ b/edge/pkg/edgehub/common/cacheutil/cache.go
@@ -24,7 +24,7 @@ func NewMetaCache() *EdgeCache {
 }
 
 func (ec *EdgeCache) SaveToCache(m *model.Message) error {
-	hash := fmt.Sprintf("%s-%s", m.Router.Resource, m.Router.Operation)
+	hash := fmt.Sprintf("%s-%s-%s", m.GetResource(), m.GetOperation(), m.GetSource())
 	ec.cacheStore[hash] = m
 	ec.sortIndex(hash)
 	return nil
@@ -53,7 +53,7 @@ func toMd5(v string) string {
 	return hex.EncodeToString(m.Sum(nil))
 }
 func (ec *EdgeCache) sortIndex(hash string) {
-	klog.Errorf("ec cacheIndex: %v", ec.cacheIndex)
+	klog.Info("ec cacheIndex: %v", ec.cacheIndex)
 	for index, item := range ec.cacheIndex {
 		if item == hash {
 			if (index + 1) != len(ec.cacheIndex) {

--- a/edge/pkg/edgehub/common/cacheutil/cache.go
+++ b/edge/pkg/edgehub/common/cacheutil/cache.go
@@ -1,0 +1,71 @@
+package cacheutil
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/kubeedge/beehive/pkg/core/model"
+	"k8s.io/klog/v2"
+)
+
+type EdgeCache struct {
+	cacheStore map[string]*model.Message
+	cacheIndex []string
+	enabled    bool
+}
+
+func NewMetaCache() *EdgeCache {
+	return &EdgeCache{
+		cacheStore: map[string]*model.Message{},
+		cacheIndex: []string{},
+		enabled:    false,
+	}
+}
+
+func (ec *EdgeCache) SaveToCache(m *model.Message) error {
+	hash := fmt.Sprintf("%s-%s", m.Router.Resource, m.Router.Operation)
+	ec.cacheStore[hash] = m
+	ec.sortIndex(hash)
+	return nil
+}
+func (ec *EdgeCache) GetCache() map[string]*model.Message {
+	return ec.cacheStore
+}
+func (ec *EdgeCache) RemoveCache(key string) {
+	delete(ec.cacheStore, key)
+}
+
+func (ec *EdgeCache) GetCacheIndex() []string {
+	return ec.cacheIndex
+}
+func (ec *EdgeCache) SetEnabled(enable bool) {
+	ec.enabled = enable
+}
+func (ec *EdgeCache) IsEnabled() bool {
+	return ec.enabled
+}
+
+func toMd5(v string) string {
+	d := []byte(v)
+	m := md5.New()
+	m.Write(d)
+	return hex.EncodeToString(m.Sum(nil))
+}
+func (ec *EdgeCache) sortIndex(hash string) {
+	klog.Errorf("ec cacheIndex: %v", ec.cacheIndex)
+	for index, item := range ec.cacheIndex {
+		if item == hash {
+			if (index + 1) != len(ec.cacheIndex) {
+				copy(ec.cacheIndex[index:], ec.cacheIndex[index+1:])
+				ec.cacheIndex[len(ec.cacheIndex)-1] = hash
+			}
+			return
+		}
+	}
+	ec.cacheIndex = append(ec.cacheIndex, hash)
+
+}
+func (ec *EdgeCache) CleanIndex() {
+	ec.cacheIndex = ec.cacheIndex[0:0]
+}

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -63,6 +63,7 @@ func (eh *EdgeHub) Enable() bool {
 func (eh *EdgeHub) Start() {
 	eh.certManager = certificate.NewCertManager(config.Config.EdgeHub, config.Config.NodeName)
 	eh.certManager.Start()
+	eh.initCache()
 
 	HasTLSTunnelCerts <- true
 	close(HasTLSTunnelCerts)

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -86,13 +86,14 @@ func (eh *EdgeHub) Start() {
 
 		err = eh.chClient.Init()
 		if err != nil {
-			eh.cacheOnEdge()
+			eh.enableCache()
 			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
 			time.Sleep(waitTime)
 			continue
 		}
 		// execute hook func after connect
 		eh.pubConnectInfo(true)
+		eh.disableCache()
 		go eh.routeToEdge()
 		go eh.routeToCloud()
 		go eh.keepalive()

--- a/edge/pkg/edgehub/edgehub.go
+++ b/edge/pkg/edgehub/edgehub.go
@@ -86,6 +86,7 @@ func (eh *EdgeHub) Start() {
 
 		err = eh.chClient.Init()
 		if err != nil {
+			eh.cacheOnEdge()
 			klog.Errorf("connection failed: %v, will reconnect after %s", err, waitTime.String())
 			time.Sleep(waitTime)
 			continue

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -135,16 +135,18 @@ func (eh *EdgeHub) routeToCloud() {
 	}
 }
 func (eh *EdgeHub) cacheToCloud() error {
+	edgeCache.GetLock()
+	defer edgeCache.ReleaseLock()
 	klog.Infof("start sending cache to cloud")
-	ci := edgeCache.GetCacheIndex()
 	cache := edgeCache.GetCache()
-	for len(ci) > 0 {
-		name := ci[0]
-		err := eh.chClient.Send(*cache[name])
+	for edgeCache.GetIndexLength() > 0 {
+		name := edgeCache.GetFirstIndex()
+		err := eh.sendToCloud(*cache[name])
 		if err != nil {
 			return err
 		}
-		ci = ci[1:]
+		klog.Infof("successfully send cache %s to cloud", name)
+		edgeCache.ShiftIndex()
 		edgeCache.RemoveCache(name)
 	}
 	klog.Infof("finished sending cache to cloud")

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -134,22 +134,25 @@ func (eh *EdgeHub) routeToCloud() {
 		}
 	}
 }
-func (eh *EdgeHub) cacheToCloud() {
-	if !edgeCache.IsEnabled() {
-		return
-	}
-	edgeCache.SetEnabled(false)
+func (eh *EdgeHub) cacheToCloud() error {
 	klog.Infof("start sending cache to cloud")
 	ci := edgeCache.GetCacheIndex()
 	cache := edgeCache.GetCache()
 	for _, name := range ci {
-		eh.chClient.Send(*cache[name])
+		err := eh.chClient.Send(*cache[name])
+		if err != nil {
+			return err
+		}
 		edgeCache.RemoveCache(name)
 	}
 	edgeCache.CleanIndex()
 	klog.Infof("finished sending cache to cloud")
+	return nil
 }
-func (eh *EdgeHub) cacheOnEdge() {
+func (eh *EdgeHub) disableCache() {
+	edgeCache.SetEnabled(false)
+}
+func (eh *EdgeHub) enableCache() {
 	if edgeCache.IsEnabled() {
 		return
 	}
@@ -165,6 +168,10 @@ func (eh *EdgeHub) cacheOnEdge() {
 			}
 			if !edgeCache.IsEnabled() {
 				klog.Infof("stop caching on edge")
+				err := eh.cacheToCloud()
+				if err != nil {
+					klog.Warning("sending Cache to cloud failed: %v", err)
+				}
 				return
 			}
 			message, err := beehiveContext.Receive(ModuleNameEdgeHub)
@@ -210,9 +217,6 @@ func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 	content := connect.CloudConnected
 	if !isConnected {
 		content = connect.CloudDisconnected
-		eh.cacheOnEdge()
-	} else {
-		eh.cacheToCloud()
 	}
 
 	for _, group := range groupMap {

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -138,14 +138,15 @@ func (eh *EdgeHub) cacheToCloud() error {
 	klog.Infof("start sending cache to cloud")
 	ci := edgeCache.GetCacheIndex()
 	cache := edgeCache.GetCache()
-	for _, name := range ci {
+	for len(ci) > 0 {
+		name := ci[0]
 		err := eh.chClient.Send(*cache[name])
 		if err != nil {
 			return err
 		}
+		ci = ci[1:]
 		edgeCache.RemoveCache(name)
 	}
-	edgeCache.CleanIndex()
 	klog.Infof("finished sending cache to cloud")
 	return nil
 }

--- a/edge/pkg/edgehub/process.go
+++ b/edge/pkg/edgehub/process.go
@@ -135,8 +135,11 @@ func (eh *EdgeHub) routeToCloud() {
 	}
 }
 func (eh *EdgeHub) cacheToCloud() {
+	if !edgeCache.IsEnabled() {
+		return
+	}
+	edgeCache.SetEnabled(false)
 	klog.Infof("start sending cache to cloud")
-
 	ci := edgeCache.GetCacheIndex()
 	cache := edgeCache.GetCache()
 	for _, name := range ci {
@@ -144,6 +147,38 @@ func (eh *EdgeHub) cacheToCloud() {
 		edgeCache.RemoveCache(name)
 	}
 	edgeCache.CleanIndex()
+	klog.Infof("finished sending cache to cloud")
+}
+func (eh *EdgeHub) cacheOnEdge() {
+	if edgeCache.IsEnabled() {
+		return
+	}
+	edgeCache.SetEnabled(true)
+	klog.Infof("start caching on edge")
+	go func() {
+		for {
+			select {
+			case <-beehiveContext.Done():
+				klog.Warning("EdgeHub CacheOnEdge stop")
+				return
+			default:
+			}
+			if !edgeCache.IsEnabled() {
+				klog.Infof("stop caching on edge")
+				return
+			}
+			message, err := beehiveContext.Receive(ModuleNameEdgeHub)
+			if err != nil {
+				klog.Errorf("failed to receive message from edge: %v", err)
+				time.Sleep(time.Second)
+				continue
+			}
+
+			// save message to cache
+			edgeCache.SaveToCache(&message)
+
+		}
+	}()
 }
 
 func (eh *EdgeHub) keepalive() {
@@ -169,40 +204,14 @@ func (eh *EdgeHub) keepalive() {
 		time.Sleep(time.Duration(config.Config.Heartbeat) * time.Second)
 	}
 }
-func (eh *EdgeHub) cacheOnEdge() {
-	klog.Infof("start caching on edge")
-	for {
-		select {
-		case <-beehiveContext.Done():
-			klog.Warning("EdgeHub CacheOnEdge stop")
-			return
-		default:
-		}
-		if !edgeCache.IsEnabled() {
-			return
-		}
-		message, err := beehiveContext.Receive(ModuleNameEdgeHub)
-		if err != nil {
-			klog.Errorf("failed to receive message from edge: %v", err)
-			time.Sleep(time.Second)
-			continue
-		}
-
-		// save message to cache
-		edgeCache.SaveToCache(&message)
-
-	}
-}
 
 func (eh *EdgeHub) pubConnectInfo(isConnected bool) {
 	// var info model.Message
 	content := connect.CloudConnected
 	if !isConnected {
 		content = connect.CloudDisconnected
-		edgeCache.SetEnabled(!isConnected)
-		go eh.cacheOnEdge()
+		eh.cacheOnEdge()
 	} else {
-		edgeCache.SetEnabled(!isConnected)
 		eh.cacheToCloud()
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:
When edgenode is offline ,metaserver and devicecontroller will continously send msg to edgehub through beehive which will cause channel full warning when the message piles up to 5000. We added a cache mechanism to merge duplicate messages, so that the message count will barely hit the limit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
